### PR TITLE
Updating webviewer to v11 and updating dark theme code

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -14,7 +14,8 @@ WebViewer({
     // const Annotations = instance.Core.Annotations;
 
     // change to dark theme
-    instance.UI.setTheme('dark');
+    const theme = instance.UI.Theme;
+    instance.UI.setTheme(theme.DARK);
 
     documentViewer.addEventListener('documentLoaded', function() {
     // call methods relating to the loaded document

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "supervisor": "^0.12.0"
   },
   "dependencies": {
-    "@pdftron/webviewer": "^10.12.0",
+    "@pdftron/webviewer": "^11.0.0",
     "concurrently": "^8.2.2"
   }
 }


### PR DESCRIPTION
Updated webviewer to v11 and fixed dark theme code.
There is an error in the console on first load when running `npm start`, but otherwise works without issues.

![Screenshot 2024-11-05 at 5 23 46 PM](https://github.com/user-attachments/assets/fec53af2-1a76-4ede-a5b4-cd13be478569)
